### PR TITLE
Removes setup dependency on pytest-runner

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setup(
     author_email=module_info.get('__contact__'),
     url=module_info.get('__url__'),
     license=module_info.get('__license__'),
-    setup_requires=['pytest-runner'],
     tests_require=['pytest'],
     keywords='tor',
     install_requires=[


### PR DESCRIPTION
This dependency is only useful to be able to run tests using setup.py,
which is not something that is done. This allows us to drop a dependency
and make packaging for distributions easier.

Fixes: #15