### PR TITLE
Trivial additions to README_SECURITY.md

### DIFF
--- a/README_SECURITY.md
+++ b/README_SECURITY.md
@@ -80,7 +80,7 @@ The vanguards addon has additional checks to detect activity related to these at
 
 ## Adversaries: Local
 
-Local adversaries include your ISP, hosting provider, or VPN, as well as the
+Local adversaries include your WiFi router administrator, your ISP, hosting provider, or VPN, as well as the
 ISP or hosting provider of the entry relays you use to connect to the Tor
 network, and any other ISPs and routers along your path to the Tor network.
 
@@ -98,7 +98,7 @@ relays is public, and connections to them are obvious. (Unless you use bridges,
 of course, which is one of our later recommendations).
 
 Local adversaries can guess that your Tor client might be an unknown onion
-service because it exhibits traffic patterns that are unlike most other Tor
+service because [it exhibits traffic patterns](https://www.usenix.org/node/190967) that are unlike most other Tor
 clients. Your connections will stay open all of the time, and you will
 regularly transmit data while other nearby humans are asleep, as well as while
 they are awake. Your traffic will also be asymmetrical. While most Tor clients


### PR DESCRIPTION
This branch includes some trivial additions to the security doc. Namely:
- Adds the threat of the WiFi administrator to local adversaries
- Link to USENIX circuit fpring paper.

Two more thoughts that I didn't know how to patch:
- The `Consider Running Tor Relays Or Bridges` section runs against the #8742 guideline's and will make Tor warn the following if an HS is also a relay:
```
Tor is currently configured as a relay and a hidden service. That's not very secure: you should probably run your hidden service in a separate Tor process, at least -- see https://trac.torproject.org/8742
```
  We should figure out if this is something we want to support and we should perhaps mention that advanced users can ignore that warning if we feel that's right.

- I feel like the `What can I do to be safer?` section ends up being pretty long. It's also a bit unstructured and complicates the otherwise pretty structured first half of the post. Perhaps we could split, or maybe it's fine as is.