### PR TITLE
Python 3.12 compatibility

### DIFF
--- a/src/vanguards/config.py
+++ b/src/vanguards/config.py
@@ -16,9 +16,12 @@ from . import logger
 from .logger import plog
 
 try:
-  from configparser import SafeConfigParser, Error
+  from configparser import ConfigParser, Error
 except ImportError:
   from ConfigParser import SafeConfigParser, Error
+  class ConfigParser(SafeConfigParser):
+      def read_file(self, f, source=None):
+          return self.readfp(f, source)
 
 ################# Global options ##################
 
@@ -209,7 +212,7 @@ def set_options_from_module(config, module, section):
       config.set(section, param, str(val))
 
 def generate_config():
-  config = SafeConfigParser(allow_no_value=True)
+  config = ConfigParser(allow_no_value=True)
   set_options_from_module(config, sys.modules[__name__], "Global")
   set_options_from_module(config, vanguards, "Vanguards")
   set_options_from_module(config, bandguards, "Bandguards")
@@ -219,9 +222,9 @@ def generate_config():
   return config
 
 def apply_config(config_file):
-  config = SafeConfigParser(allow_no_value=True)
+  config = ConfigParser(allow_no_value=True)
 
-  config.readfp(open(config_file, "r"))
+  config.read_file(open(config_file, "r"))
 
   get_options_for_module(config, sys.modules[__name__], "Global")
   get_options_for_module(config, vanguards, "Vanguards")


### PR DESCRIPTION
Python 3.12 removes the deprecated `SafeConfigParser` class. This patch switches the code to using `ConfigParser` and `read_file` from Python 3.x, and patches 2.7's `SafeConfigParser` to a compatible definition.